### PR TITLE
Created flake.nix and default.nix to package for Nix(OS)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,15 @@
+{ buildGoModule, fetchFromGitHub }:
+{
+  default = buildGoModule {
+    pname = "muxie";
+    version = "1.1.0";
+    subPackages = [ "cmd/muxie" ];
+    src = fetchFromGitHub {
+      owner = "phanorcoll";
+      repo = "muxie";
+      rev = "65c7e7101f8a2c83fae9181907e1b01094dd9be2";
+      hash = "sha256-JO6b1Nbm82FLnTSK7sKdZVTNIUznwwFcFU/dxpHu5pM=";
+    };
+    vendorHash = "sha256-CXd2j180T9ln21RTBCqCqdO32aeNIXHwiPRNcFPFt2I=";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Muxie";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      allSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
+    in
+    {
+      packages = forAllSystems ({ pkgs }: pkgs.callPackage ./. { });
+    };
+}


### PR DESCRIPTION
This PR adds a simple `flake.nix` and `default.nix` to allow Nix and NixOS users to build and include `muxie` in their system configurations.

If you wish to keep OS package manager files separate from this repo, I can host a separate repo that simply references this one and builds the same. If you do wish to merge it, I will make future PRs to update the `.nix` files with the current release version as it changes.

But regardless, great application! Very comfortable keybinds and nice look!