### PR TITLE
Consider when `pane-base-index` is not 1 (i.e. 0)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,14 +23,16 @@ type Session struct {
 
 // Window represents a window within a session, containing multiple panes split in a layout.
 type Window struct {
-	Name   string `yaml:"name"`
-	Panes  []Pane `yaml:"panes"`
-	Layout string `yaml:"layout"`
+	Name      string `yaml:"name"`
+	Directory string `yaml:"directory"`
+	Panes     []Pane `yaml:"panes"`
+	Layout    string `yaml:"layout"`
 }
 
 // Pane defines a single pane within a window, with its associated command.
 type Pane struct {
-	Command string `yaml:"command"`
+	Command   string `yaml:"command"`
+	Directory string `yaml:"directory"`
 }
 
 // createExampleConfigFile creates an example configuration file if one does not already exist.

--- a/internal/tmux/start.go
+++ b/internal/tmux/start.go
@@ -3,21 +3,33 @@ package tmux
 
 import (
 	"fmt"
-
 	"github.com/phanorcoll/muxie/internal/config"
 )
 
 // StartSession creates a new tmux session with the given sessionName and starting directory.
 // It then creates the specified windows and panes, running the configured commands in each pane.
 // Returns an error if any tmux operation fails.
-func StartSession(sessionName, dir string, windows []config.Window) error {
-	if err := CreateSession(sessionName, dir); err != nil {
+func StartSession(sessionName, sessionDirectory string, windows []config.Window) error {
+	if err := CreateSession(sessionName, sessionDirectory); err != nil {
 		return fmt.Errorf("failed to create new session '%s': %w", sessionName, err)
 	}
-	directory := expandHomeDir(dir)
+	sessionDirectory = expandHomeDir(sessionDirectory)
+
+	// Get the base pane index, which we will use several times
+	// while starting a predefined session
+	basePaneIndex, err := GetPaneBaseIndex()
+	if err != nil {
+		return err
+	}
+
 	for _, w := range windows {
-		if err := NewWindow(sessionName, w.Name, directory); err != nil {
+		if err := NewWindow(sessionName, w.Name, sessionDirectory); err != nil {
 			return fmt.Errorf("failed to create window '%s' in session '%s': %w", w.Name, sessionName, err)
+		}
+
+		windowDirectory := sessionDirectory
+		if w.Directory != "" {
+			windowDirectory = expandHomeDir(w.Directory)
 		}
 
 		for j, p := range w.Panes {
@@ -26,10 +38,23 @@ func StartSession(sessionName, dir string, windows []config.Window) error {
 					return fmt.Errorf("failed to split window '%s' in session '%s': %w", w.Name, sessionName, err)
 				}
 			}
-			if err := SendKeys(sessionName, w.Name, j, fmt.Sprintf("cd %s && clear && %s", directory, p.Command)); err != nil {
+
+			paneDirectory := windowDirectory 
+			if p.Directory != "" {
+				paneDirectory = expandHomeDir(p.Directory)
+			}
+
+			if err := SendKeys(sessionName, w.Name, basePaneIndex + j, fmt.Sprintf("cd %s && clear && %s", paneDirectory, p.Command)); err != nil {
 				return fmt.Errorf("failed to send keys to pane %d in window '%s' of session '%s': %w", j, w.Name, sessionName, err)
 			}
 		}
+	}
+
+	// After starting the predefined session, delete its starting window
+	// as it is not part of the user's config file
+	err = KillWindow(sessionName, basePaneIndex)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 // SessionData represents information about a tmux session,
@@ -89,6 +89,17 @@ func KillSession(name string) error {
 	return nil
 }
 
+// KillWindow kills the tmux window with the given session name and window index.
+// Returns an error if the command fails.
+func KillWindow(sessionName string, index int) error {
+	cmd := exec.Command("tmux", "kill-window", "-t", fmt.Sprintf("%s:%d", sessionName, index))
+	if err := cmd.Run(); err != nil {
+		log.Println("Error killing session:", err)
+		return err
+	}
+	return nil
+}
+
 // GetActiveSession returns the name of the currently active tmux session.
 // Returns an empty string if there is no active session.
 func GetActiveSession() (string, error) {
@@ -145,7 +156,7 @@ func GetPaneBaseIndex() (int, error) {
 
 	i, err := strconv.Atoi(result_trimmed)
 	if err != nil {
-		return -1, fmt.Errorf("Failed to convert pane-base-index to integer", err)
+		return -1, fmt.Errorf("Failed to convert pane-base-index to integer %s", err)
 	}
 
 	return i, nil
@@ -157,11 +168,7 @@ func GetPaneBaseIndex() (int, error) {
 // paneIndex: the index of the pane (0-based).
 // keys: the command or keys to send.
 func SendKeys(sessionName, windowName string, paneIndex int, keys string) error {
-	basePaneIndex, err := GetPaneBaseIndex()
-	if err != nil {
-		return err
-	}
-	target := fmt.Sprintf("%s:%s.%d", sessionName, windowName, paneIndex + basePaneIndex)
+	target := fmt.Sprintf("%s:%s.%d", sessionName, windowName, paneIndex)
 	cmd := exec.Command("tmux", "send-keys", "-t", target)
 	if keys != "" {
 		cmd.Args = append(cmd.Args, keys, "C-m")


### PR DESCRIPTION
The `SendKeys` function previously did not consider the tmux variable `pane-base-index`, so I just added a helper function to grab that value, parse it, and add it to the `paneIndex`. 

I don't usually program in Go, so let me know if you want me to change anything to match documentation/code convention.