### PR TITLE
Nix Flake: update `src` to be the most up to date revision.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,12 @@
-{ buildGoModule, fetchFromGitHub }:
+{
+  buildGoModule,
+}:
 {
   default = buildGoModule {
     pname = "muxie";
     version = "1.1.0";
     subPackages = [ "cmd/muxie" ];
-    src = fetchFromGitHub {
-      owner = "phanorcoll";
-      repo = "muxie";
-      rev = "65c7e7101f8a2c83fae9181907e1b01094dd9be2";
-      hash = "sha256-JO6b1Nbm82FLnTSK7sKdZVTNIUznwwFcFU/dxpHu5pM=";
-    };
+    src = ./.;
     meta.mainProgram = "muxie";
     vendorHash = "sha256-CXd2j180T9ln21RTBCqCqdO32aeNIXHwiPRNcFPFt2I=";
   };


### PR DESCRIPTION
I don't know why I brain farted before and pinned the src to a specific Github revision (which prevents the package from being updated lol). Anyways, this should fix it and keep things up to date automatically.

Also, this is a duplicate branch of the `origin/nix-flake`, which I accidentally deleted. I've restored it here and renamed it to get rid of the `origin/` prefix, which seemed to have been added to the name thanks to some Neogit bug. Once again, apologies for the confusion.